### PR TITLE
Use a separate url for replies for sms transport

### DIFF
--- a/vxvas2nets/tests/test_vas2nets_sms.py
+++ b/vxvas2nets/tests/test_vas2nets_sms.py
@@ -2,6 +2,7 @@
 
 import json
 from urllib import urlencode
+from urlparse import urljoin
 
 from twisted.web import http
 from twisted.internet import reactor
@@ -34,7 +35,8 @@ class TestVas2NetsSmsTransport(VumiTestCase):
             'web_port': 0,
             'web_path': '/api/v1/vas2nets/sms/',
             'publish_status': True,
-            'outbound_url': self.remote_server.url,
+            'outbound_url': urljoin(self.remote_server.url, 'nonreply'),
+            'reply_outbound_url': urljoin(self.remote_server.url, 'reply'),
             'username': 'root',
             'password': 't00r',
         }
@@ -171,6 +173,8 @@ class TestVas2NetsSmsTransport(VumiTestCase):
             content='hi')
 
         [req] = reqs
+
+        self.assertTrue(req.uri.startswith('/nonreply'))
         self.assertEqual(req.method, 'GET')
         self.assertEqual(req.args, {
             'username': ['root'],
@@ -203,6 +207,7 @@ class TestVas2NetsSmsTransport(VumiTestCase):
         yield self.tx_helper.dispatch_outbound(msg)
 
         [req] = reqs
+        self.assertTrue(req.uri.startswith('/reply'))
         self.assertEqual(req.method, 'GET')
         self.assertEqual(req.args, {
             'username': ['root'],

--- a/vxvas2nets/vas2nets_sms.py
+++ b/vxvas2nets/vas2nets_sms.py
@@ -106,9 +106,7 @@ class Vas2NetsSmsTransport(HttpRpcTransport):
         }
 
     def get_outbound_url(self, message):
-        id = get_in(message, 'transport_metadata', 'vas2nets_sms', 'msgid')
-
-        if id is not None:
+        if self.use_mo_response_url() and self.is_mo_response(message):
             return self.config['reply_outbound_url']
         else:
             return self.config['outbound_url']
@@ -127,10 +125,13 @@ class Vas2NetsSmsTransport(HttpRpcTransport):
         # from docs:
         # If MO Message ID is validated, MT will not be charged.
         # Only one free MT is allowed for each MO.
-        if id is not None:
+        if id is not None and self.use_mo_response_url():
             params['message_id'] = id
 
         return params
+
+    def use_mo_response_url(self):
+        return self.config.get('reply_outbound_url') is not None
 
     def is_mo_response(self, message):
         return get_in(message, 'transport_metadata', 'vas2nets_sms', 'msgid')

--- a/vxvas2nets/vas2nets_sms.py
+++ b/vxvas2nets/vas2nets_sms.py
@@ -134,8 +134,6 @@ class Vas2NetsSmsTransport(HttpRpcTransport):
 
     @inlineCallbacks
     def handle_raw_inbound_message(self, message_id, request):
-        log.msg("asfsdf")
-
         try:
             vals, errors = self.get_field_values(request, self.EXPECTED_FIELDS)
         except UnicodeDecodeError:


### PR DESCRIPTION
From the API docs:

```
If MO Message ID is validated, MT will not be charged.
Only one free MT is allowed for each MO.
```

I only noticed now that replies should be sent over a different URL for this.
