### PR TITLE
Add message type parameter to outbound requests for sms transport

### DIFF
--- a/vxvas2nets/tests/test_vas2nets_sms.py
+++ b/vxvas2nets/tests/test_vas2nets_sms.py
@@ -270,6 +270,7 @@ class TestVas2NetsSmsTransport(VumiTestCase):
             'password': ['t00r'],
             'sender': ['456'],
             'receiver': ['+123'],
+            'message_type': ['1'],
         })
 
         [ack] = yield self.tx_helper.wait_for_dispatched_events(1)
@@ -319,7 +320,8 @@ class TestVas2NetsSmsTransport(VumiTestCase):
             'password': ['t00r'],
             'sender': ['456'],
             'receiver': ['+123'],
-            'message_id': ['789']
+            'message_id': ['789'],
+            'message_type': ['1'],
         })
 
         [ack] = yield self.tx_helper.wait_for_dispatched_events(1)
@@ -369,6 +371,7 @@ class TestVas2NetsSmsTransport(VumiTestCase):
             'password': ['t00r'],
             'sender': ['456'],
             'receiver': ['+123'],
+            'message_type': ['1'],
         })
 
         [ack] = yield self.tx_helper.wait_for_dispatched_events(1)

--- a/vxvas2nets/vas2nets_sms.py
+++ b/vxvas2nets/vas2nets_sms.py
@@ -118,6 +118,7 @@ class Vas2NetsSmsTransport(HttpRpcTransport):
             'sender': message['from_addr'],
             'receiver': message['to_addr'],
             'message': message['content'],
+            'message_type': '1',
         }
 
         id = get_in(message, 'transport_metadata', 'vas2nets_sms', 'msgid')

--- a/vxvas2nets/vas2nets_sms.py
+++ b/vxvas2nets/vas2nets_sms.py
@@ -118,6 +118,13 @@ class Vas2NetsSmsTransport(HttpRpcTransport):
             'sender': message['from_addr'],
             'receiver': message['to_addr'],
             'message': message['content'],
+
+            # From docs:
+            # flag indicating normal text message
+            # 0 or 1  Note: 1=flash, 0=text (This is optional, the default is 0
+            # i.e text)
+            # From testing, it appears they are expecting this value to always
+            # be 1
             'message_type': '1',
         }
 


### PR DESCRIPTION
This parameter isn't something we need, and according to the docs is optional, but from testing it seemed necessary for it to be provided.
